### PR TITLE
Deploy Solid example for smoke testing

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -10,8 +10,11 @@ on:
       - "package.json"
       - "sst.config.ts"
       - "infra/**"
-      - "packages/frontpage"
-      - "packages/docs"
+      - "examples/solid/**"
+      - "packages/browser/**"
+      - "packages/docs/**"
+      - "packages/frontpage/**"
+      - "packages/spotify-effect/**"
       - "turbo.json"
   workflow_dispatch:
     inputs:
@@ -57,3 +60,9 @@ jobs:
           CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
           CLOUDFLARE_DEFAULT_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_DEFAULT_ACCOUNT_ID }}
         run: bun run sst deploy --stage=prod
+
+      - name: Smoke test Spotify example
+        run: >-
+          curl --fail --silent --show-error
+          --retry 5 --retry-all-errors --retry-delay 5
+          https://example.spotify.opensound.dev/

--- a/README.md
+++ b/README.md
@@ -23,7 +23,13 @@ This is an **isomorphic** (works in both Node.js and browser environments) Effec
 
 - **`examples/basic`** — Node.js example with tracing
 - **`examples/browser`** — Browser-based PKCE authentication flow
+- **`examples/solid`** — Deployable SolidJS browser example for PKCE and authenticated API smoke tests
 - **`examples/otel`** — Ready-to-run OpenTelemetry collector stack
+
+The SolidJS example is continuously deployed from `main` to
+[`example.spotify.opensound.dev`](https://example.spotify.opensound.dev). Enter a Spotify client ID
+whose redirect URIs include `https://example.spotify.opensound.dev/` to smoke test PKCE, session
+refresh, profile requests, and library requests against the deployed packages.
 
 ## Quick Start
 

--- a/infra/dns.ts
+++ b/infra/dns.ts
@@ -1,3 +1,4 @@
 export const zoneDomain = "opensound.dev";
 export const frontpageDomain = zoneDomain;
 export const docsDomain = `spotify.${zoneDomain}`;
+export const spotifyExampleDomain = `example.spotify.${zoneDomain}`;

--- a/infra/web.ts
+++ b/infra/web.ts
@@ -1,4 +1,4 @@
-import { docsDomain, frontpageDomain } from "./dns";
+import { docsDomain, frontpageDomain, spotifyExampleDomain } from "./dns";
 
 export const frontpage = new sst.cloudflare.StaticSiteV2("frontpage", {
   path: "./packages/frontpage",
@@ -19,7 +19,17 @@ export const docs = new sst.cloudflare.StaticSiteV2("docs", {
   notFound: "404",
 });
 
+export const spotifyExample = new sst.cloudflare.StaticSiteV2("spotify-example", {
+  path: "./examples/solid",
+  build: {
+    command: "bun run build",
+    output: "dist",
+  },
+  domain: spotifyExampleDomain,
+});
+
 export const outputs = {
   frontpage: frontpage.url,
   docs: docs.url,
+  spotifyExample: spotifyExample.url,
 };


### PR DESCRIPTION
## Summary
- deploy the SolidJS example as an SST Cloudflare static site
- expose it at example.spotify.opensound.dev
- redeploy when the example or its core/browser dependencies change
- verify the public URL after each deployment
- document the deployed PKCE smoke-test flow

## Verification
- bun run --filter @examples/solid build
- production artifact served locally with Vite preview
- curl returned HTTP 200 for the built static entry
- agent-browser rendered the app with no page or console errors
- entering a dummy client ID enabled the Spotify login action
- SST production diff planned the static site, Worker router, and custom domain

## Notes
- bun install --frozen-lockfile currently fails on origin/main because released workspace versions are ahead of the lockfile workspace metadata; this PR does not normalize that unrelated drift

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Deploy the SolidJS example as an SST Cloudflare static site at https://example.spotify.opensound.dev with a CI smoke test that verifies availability after each deploy. The workflow redeploys when the example or related browser packages change.

- **New Features**
  - Added `spotifyExample` static site in `infra/web.ts` with domain `spotifyExampleDomain` (`example.spotify.opensound.dev`) and exposed its URL in outputs.
  - Updated deploy workflow to watch `examples/solid` and related packages (`packages/browser`, `packages/spotify-effect`, `packages/docs`, `packages/frontpage`), then added a curl smoke test with retries.
  - Updated README to document the deployed example and PKCE smoke-test flow.

<sup>Written for commit 7e8edcb2bebd920a36a04c0fbfd329633d7beb20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/planetaryescape/opensound/pull/51?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

