### PR TITLE
chore: cut Effect beta.99 release

### DIFF
--- a/.changeset/effect-beta-99.md
+++ b/.changeset/effect-beta-99.md
@@ -1,0 +1,7 @@
+---
+"@spotify-effect/core": patch
+"@spotify-effect/browser": patch
+"@spotify-effect/otel-node": patch
+---
+
+Upgrade the Spotify Effect package family to Effect 4.0.0-beta.99.


### PR DESCRIPTION
## Summary
- add a patch changeset for the fixed Spotify Effect package family
- prepare @spotify-effect/core, @spotify-effect/browser, and @spotify-effect/otel-node 0.6.4

## Verification
- bun run ci

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepare patch releases for `@spotify-effect/core`, `@spotify-effect/browser`, and `@spotify-effect/otel-node` to align with Effect 4.0.0-beta.99. Adds a changeset to cut the beta.99 release.

<sup>Written for commit dade04ca1f0ad48ebf3f9daf2b0b191a45c65b10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/planetaryescape/opensound/pull/52?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Spotify Effect packages to the `Effect 4.0.0-beta.99` patch release.
  * Recorded the coordinated package version updates in the release notes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->